### PR TITLE
Correct multiline yaml syntax in ability files

### DIFF
--- a/data/abilities/collection/316f2be2-3103-4065-a128-50ae3456e7f3.yml
+++ b/data/abilities/collection/316f2be2-3103-4065-a128-50ae3456e7f3.yml
@@ -14,7 +14,7 @@
   platforms:
     windows:
       psh:
-        command: |
+        command: >
           .\dnp3actions.exe #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link} integrity-poll
         payloads:
         - dnp3actions.exe

--- a/data/abilities/collection/7f68f5b0-1bc8-4fee-baa5-ab7e95ec2782.yml
+++ b/data/abilities/collection/7f68f5b0-1bc8-4fee-baa5-ab7e95ec2782.yml
@@ -15,7 +15,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           read --group #{dnp3.object.group} --variation #{dnp3.object.variation} --start #{dnp3.start.index} --end #{dnp3.end.index}
         payloads:

--- a/data/abilities/collection/a2c8f215-d4d8-4e2b-b73f-6d33ecc89028.yml
+++ b/data/abilities/collection/a2c8f215-d4d8-4e2b-b73f-6d33ecc89028.yml
@@ -16,7 +16,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe  #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           enable-messages --classes #{dnp3.message.class1} #{dnp3.message.class2} #{dnp3.message.class3}
         payloads:

--- a/data/abilities/impact/14b02f84-e3dd-4297-837b-8b5b7056dd52.yml
+++ b/data/abilities/impact/14b02f84-e3dd-4297-837b-8b5b7056dd52.yml
@@ -16,8 +16,8 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
-          .\dnp3actions.exe  #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
+        command: >
+          .\dnp3actions.exe #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           toggle-sbo --index #{dnp3.server.index} --iterations #{dnp3.operate.iterations}
           --trip-on #{dnp3.trip.on} --trip-off #{dnp3.trip.off} --on-time #{dnp3.on.time} --off-time #{dnp3.off.time}
         payloads:

--- a/data/abilities/impact/1a3600f7-f434-46f0-82f8-7a7a355f62cb.yml
+++ b/data/abilities/impact/1a3600f7-f434-46f0-82f8-7a7a355f62cb.yml
@@ -16,7 +16,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe  #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           toggle-sbo-range --start #{dnp3.start.index} --end #{dnp3.end.index} --iterations #{dnp3.operate.iterations}
           --trip-on #{dnp3.trip.on} --trip-off #{dnp3.trip.off} --on-time #{dnp3.on.time} --off-time #{dnp3.off.time}

--- a/data/abilities/impact/2a4109a7-5a44-42a5-8944-83b0ba93ed47.yml
+++ b/data/abilities/impact/2a4109a7-5a44-42a5-8944-83b0ba93ed47.yml
@@ -15,7 +15,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe  #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           toggle-off-do --start #{dnp3.start.index} --end #{dnp3.end.index}
         payloads:

--- a/data/abilities/impact/3c0839b3-3335-47cd-b3fe-f0ae127a4903.yml
+++ b/data/abilities/impact/3c0839b3-3335-47cd-b3fe-f0ae127a4903.yml
@@ -15,7 +15,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe  #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           toggle-on-do --start #{dnp3.start.index} --end #{dnp3.end.index}
         payloads:

--- a/data/abilities/impact/4f8c7df8-5031-4d36-ae58-d3509976bd9d.yml
+++ b/data/abilities/impact/4f8c7df8-5031-4d36-ae58-d3509976bd9d.yml
@@ -16,7 +16,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe  #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           sbo-on --start #{dnp3.start.index} --end #{dnp3.end.index} --step #{dnp3.index.step} -t 2
         payloads:

--- a/data/abilities/impact/6e8fce00-860a-47bb-a694-1528102ad56a.yml
+++ b/data/abilities/impact/6e8fce00-860a-47bb-a694-1528102ad56a.yml
@@ -15,7 +15,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           sbo-off --start #{dnp3.start.index} --end #{dnp3.end.index} --step #{dnp3.index.step} -t 1
         payloads:

--- a/data/abilities/impact/afa55ec5-4762-40ad-8d38-ac98da8f43bb.yml
+++ b/data/abilities/impact/afa55ec5-4762-40ad-8d38-ac98da8f43bb.yml
@@ -15,7 +15,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           toggle-do --index #{dnp3.server.index} --iterations #{dnp3.operate.iterations}
           --trip-on #{dnp3.trip.on} --trip-off #{dnp3.trip.off} --on-time #{dnp3.on.time} --off-time #{dnp3.off.time}

--- a/data/abilities/inhibit-response-function/69cddd4e-92e3-430f-af44-1da58f89e018.yml
+++ b/data/abilities/inhibit-response-function/69cddd4e-92e3-430f-af44-1da58f89e018.yml
@@ -15,7 +15,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link} cold-restart
         payloads:
         - dnp3actions.exe

--- a/data/abilities/inhibit-response-function/7a9cadfe-8522-422f-9e19-3953371b5474.yml
+++ b/data/abilities/inhibit-response-function/7a9cadfe-8522-422f-9e19-3953371b5474.yml
@@ -15,7 +15,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link} warm-restart
         payloads:
         - dnp3actions.exe

--- a/data/abilities/inhibit-response-function/9a65f3ea-67b9-4eff-99c4-b635f8267ea4.yml
+++ b/data/abilities/inhibit-response-function/9a65f3ea-67b9-4eff-99c4-b635f8267ea4.yml
@@ -15,7 +15,7 @@
     windows:
       psh:
         cleanup: rm dnp3actions.exe
-        command: |
+        command: >
           .\dnp3actions.exe  #{dnp3.server.ip} -p #{dnp3.server.port} #{dnp3.local.link} #{dnp3.remote.link}
           disable-messages --classes #{dnp3.message.class1} #{dnp3.message.class2} #{dnp3.message.class3}
         payloads:


### PR DESCRIPTION
Resolves #1 by changing yaml multi-line syntax to "folded" style (`>`)